### PR TITLE
disable dark theme

### DIFF
--- a/ParentingAssistant/ParentingAssistant/ParentingAssistantApp.swift
+++ b/ParentingAssistant/ParentingAssistant/ParentingAssistantApp.swift
@@ -17,6 +17,7 @@ struct ParentingAssistantApp: App {
     var body: some Scene {
         WindowGroup {
             SplashScreenView()
+                .preferredColorScheme(.light)
         }
     }
 }


### PR DESCRIPTION
This pull request includes a small change to the `ParentingAssistantApp.swift` file. The change ensures that the `SplashScreenView` is displayed using the light color scheme by default.

* [`ParentingAssistant/ParentingAssistant/ParentingAssistantApp.swift`](diffhunk://#diff-1fdebf41fddfc52bc75a35816bdcb0d01495dd3c6faa34a82d08a17231d558aaR20): Added `.preferredColorScheme(.light)` to the `SplashScreenView`.